### PR TITLE
Fix failed discovery due to BLE Timeout

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -53,11 +53,10 @@ class PaxApi extends Homey.SimpleClass {
    * Returns the name and mode of the device.
    */
   async getNameAndMode() {
-    const [name, mode] = await Promise.all([
-      this.getName(),
-      this.getMode(),
-    ]);
-    return { name, mode };
+    return {
+      name: await this.getName(),
+      mode: await this.getMode(),
+    };
   }
 
   /**


### PR DESCRIPTION
Had a issue where none of my fans was able to be found in the app. Did some debugging and found that a BLE Timeout error was thrown when basic deviceInfo was requested. Reguesting name and mode synchronous insted of asynchronous solved the issue.